### PR TITLE
Added LED class

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ## Python Modules
 * schedule
 * azure
+* rpi-gpio
 ## System
 * p7zip-full
 * sox

--- a/led.py
+++ b/led.py
@@ -1,0 +1,30 @@
+'''
+File:           led.py
+Purpose:        A class that abstracts the GPIO pins away when using LED's
+Author:         Jeremy DeHaan
+Last Updated:   May 19th, 2018
+Version:        1.0
+'''
+import RPi.GPIO as GPIO
+
+class led:
+    pin = 0
+    lit = False
+    def __init__(self, pinNumber):
+        GPIO.setmode(GPIO.BCM)
+        GPIO.setwarnings(False)
+        self.pin = pinNumber
+        GPIO.setup(self.pin,GPIO.OUT)
+
+    def on(self):
+        self.lit = True
+        GPIO.output(self.pin,GPIO.HIGH)
+
+    def off(self):
+        self.lit = False
+        GPIO.output(self.pin,GPIO.LOW)
+
+    def flip(self):
+        GPIO.output(self.pin,GPIO.LOW) if self.lit else GPIO.output(self.pin,GPIO.HIGH)
+        self.lit = not self.lit
+


### PR DESCRIPTION
This just adds a small little LED class to abstract using the GPIO pins away.

Example:
``` python
from  led import led
from time import sleep

blinky = led(18)

while True:
    blinky.flip()
    sleep(1)
```

You do have to know the pin numbers the pi uses when initializing the class, but those are easy to find out and change. I would suggest having some global constants once we get the design finalized.
